### PR TITLE
Adding CROSS_COMPILE option when not on aarch64

### DIFF
--- a/watter-build
+++ b/watter-build
@@ -37,6 +37,9 @@ dir=${BUILD_DIR:-$(pwd)/build-${target}}
 
 export HOSTCC=gcc
 export CC=gcc
+if [ "$(uname -m)" != "aarch64" ]; then
+    export CROSS_COMPILE=aarch64-linux-gnu-
+fi
 
 export MAKEFLAGS="O=$dir -j$nway KERNELRELEASE=$kver ARCH=$ARCH"
 


### PR DESCRIPTION
Added architecture check to watter-build. If not aarch64, set the CROSS_COMPILE env variable