### PR TITLE
WCS-95 Adding CROSS_COMPILE option when not on aarch64

### DIFF
--- a/watter-build
+++ b/watter-build
@@ -37,6 +37,9 @@ dir=${BUILD_DIR:-$(pwd)/build-${target}}
 
 export HOSTCC=gcc
 export CC=gcc
+if [ "$(uname -m)" != "aarch64" ]; then
+    export CROSS_COMPILE=aarch64-linux-gnu-
+fi
 
 export MAKEFLAGS="O=$dir -j$nway KERNELRELEASE=$kver ARCH=$ARCH"
 


### PR DESCRIPTION
Build was failing on dev pc due to lack of CROSS_COMPILE flag. Enabling cross compile drops build time 5x.